### PR TITLE
chore: collapse CI into a single job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,13 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    timeout-minutes: 10
-    name: lint
+  ci:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v6
 
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: |
@@ -21,52 +19,13 @@ jobs:
             21
           cache: gradle
 
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+      - uses: gradle/actions/setup-gradle@v4
 
-      - name: Run lints
+      - name: Lint
         run: ./scripts/lint
 
-  build:
-    timeout-minutes: 10
-    name: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: |
-            8
-            21
-          cache: gradle
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
-
-      - name: Build SDK
+      - name: Build
         run: ./scripts/build
 
-  test:
-    timeout-minutes: 10
-    name: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: |
-            8
-            21
-          cache: gradle
-
-      - name: Set up Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
-
-      - name: Run tests
+      - name: Test
         run: ./scripts/test


### PR DESCRIPTION
## Summary
- Collapse `lint`, `build`, `test` into a single `ci` job whose steps share one JDK + Gradle setup. The previous shape paid the same install tax three times in parallel.
- Unify on `gradle/actions/setup-gradle@v4` (drop the deprecated `gradle/gradle-build-action@v2` that the previous cleanup left in `test`).
- Use floating major-version tags for actions.

## Test plan
- Ran `git diff --check`.
- Confirmed `release.yml`, `publish-sonatype.yml`, `release-please-config.json`, and `scripts/*` are untouched.